### PR TITLE
Scale icon in page-tree

### DIFF
--- a/Resources/Public/Icons/NewsArticle.svg
+++ b/Resources/Public/Icons/NewsArticle.svg
@@ -1,4 +1,4 @@
-<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<svg fill="#000000" preserveAspectRatio="xMinYMin meet" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm-2 12H6v-2h12v2zm0-3H6V9h12v2zm0-3H6V6h12v2z"/>
     <path d="M0 0h24v24H0z" fill="none"/>
 </svg>


### PR DESCRIPTION
This scales the page-tree icon for news records in TYPO3 12.

For tests:
 1. Manually delete the old icon from LocalStorage: `key: t3-icon_apps-pagetree-justnews_small__default_inline`
 2. Completely reload the TYPO3 backend.